### PR TITLE
bugfix/15284_set_record_doesnt_check_if_aerospike_is_registered

### DIFF
--- a/lib/logstash/filters/aerospike-malware-score.rb
+++ b/lib/logstash/filters/aerospike-malware-score.rb
@@ -41,11 +41,7 @@ class LogStash::Filters::AerospikeMalwareScore < LogStash::Filters::Base
     # Add instance variables
 
     begin
-      @aerospike_server = servers if @aerospike_server.empty?
-      @aerospike_server = @aerospike_server.first if @aerospike_server.class.to_s == "Array"
-      host,port = @aerospike_server.split(":")
-      @aerospike = Client.new(Host.new(host, port))
-
+      register_aerospike
     rescue Aerospike::Exceptions::Aerospike => ex
       @logger.error(ex.message)
     end
@@ -53,6 +49,15 @@ class LogStash::Filters::AerospikeMalwareScore < LogStash::Filters::Base
   end # def register
 
   private
+
+  # Create aerospike from the first aerospike server found in aerospike config file
+  # or from "localhost:3000"
+  def register_aerospike
+    @aerospike_server = servers if @aerospike_server.empty?
+    @aerospike_server = @aerospike_server.first if @aerospike_server.class.to_s == "Array"
+    host,port = @aerospike_server.split(":")
+    @aerospike = Client.new(Host.new(host, port))
+  end
 
   # Get servers from Aerospike configuration file
   #
@@ -224,6 +229,10 @@ class LogStash::Filters::AerospikeMalwareScore < LogStash::Filters::Base
 
   public
   def filter(event)
+
+    if @aerospike.nil?
+      register_aerospike
+    end
 
     @hash = event.get(@hash_field)
     @loader_score = event.get(@loader_score_name)

--- a/logstash-filter-aerospike-malware-score.gemspec
+++ b/logstash-filter-aerospike-malware-score.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-filter-aerospike-malware-score'
-  s.version = '0.0.2'
+  s.version = '0.0.3'
   s.licenses = ['Apache-2.0']
   s.summary = "plugin to upload malware score to Aerospike"
   s.description = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Variable _@aerospike_ is sometimes _nil_ because it isn't registered. Now the filter function checks if it is registered or not, if not, calls the function _register_aerospike_ and then continues the process.

Additions:
- Created new function called _register_aerospike_ with the lines from _register_.
- _filter_ function now checks if _@aerospike_ is registered.

Removals: