### PR TITLE
get_record function not properly handling errors

### DIFF
--- a/lib/logstash/filters/aerospike-malware-score.rb
+++ b/lib/logstash/filters/aerospike-malware-score.rb
@@ -169,8 +169,8 @@ class LogStash::Filters::AerospikeMalwareScore < LogStash::Filters::Base
   #
   # @return [record,nil] Aerospike record or nil if record does not exist.
   def get_record(set)
-    key = Key.new(@namespace, set, @hash)
-    @aerospike.get(key,[], Policy.new)
+    key = Key.new(@namespace, set, @hash) rescue nil
+    @aerospike.get(key,[], Policy.new) rescue nil
   end
 
   # Set Aerospike record for given bin and set.

--- a/logstash-filter-aerospike-malware-score.gemspec
+++ b/logstash-filter-aerospike-malware-score.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-filter-aerospike-malware-score'
-  s.version = '0.0.3'
+  s.version = '0.0.4'
   s.licenses = ['Apache-2.0']
   s.summary = "plugin to upload malware score to Aerospike"
   s.description = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
The "get_record" function has been updated to handle errors more effectively. The issue has been resolved by adding a rescue mechanism in the ".get" and "Key.new" calls.




